### PR TITLE
Nissix plugin scope-packages on stylscss

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "puppeteer": "^1.1.0",
     "react-test-renderer": "~15.6.0",
     "velocity": "~0.7.0",
-    "yoshi": "^3.0.0",
+    "@wix/yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0"
   },
   "dependencies": {
@@ -39,7 +39,7 @@
     "react-dom": "15.6.1",
     "react-i18next": "~4.8.0",
     "regenerator-runtime": "^0.11.0",
-    "wix-axios-config": "latest"
+    "@wix/wix-axios-config": "latest"
   },
   "yoshi": {
     "externals": {

--- a/src/client.js
+++ b/src/client.js
@@ -2,7 +2,7 @@ import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import axios from 'axios';
-import { wixAxiosConfig } from 'wix-axios-config';
+import { wixAxiosConfig } from '@wix/wix-axios-config';
 import App from './components/App';
 
 const baseURL = window.__BASEURL__;

--- a/test/mocha-setup.js
+++ b/test/mocha-setup.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { wixAxiosConfig } from 'wix-axios-config';
+import { wixAxiosConfig } from '@wix/wix-axios-config';
 import { baseURL } from './test-common';
 
 wixAxiosConfig(axios, { baseURL });

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.657s



Output Log:
Migrating package "stylscss" in .


## Migration from non scope to @wix/scoped packages
> /tmp/5feb76e8a04730802da92b8df58ee5e2

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/client.js
test/mocha-setup.js
```

